### PR TITLE
research(report): add first reproducible PET metrics report

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -521,3 +521,116 @@ ma cattura differenze reali e misurabili. Il potere discriminante è presente
 
 Gli strumenti di analisi sono in `tools/cluster_families.py` (famiglie originali)
 e `tools/cluster_families_disjoint.py` (famiglie disgiunte).
+
+## JSONL scan record schema (v1)
+
+The `pet scan` command produces one JSON object per line (JSONL).
+Each line represents one integer `n >= 2` together with its canonical PET
+encoding and structural analysis data.
+
+### Record model
+
+A scan record in schema v1 has the following top-level structure:
+
+```json
+{
+  "schema_version": 1,
+  "n": 72,
+  "pet": [
+    {"p": 2, "e": [{"p": 3, "e": null}]},
+    {"p": 3, "e": [{"p": 2, "e": null}]}
+  ],
+  "metrics": {
+    "node_count": 4,
+    "leaf_count": 2,
+    "height": 2,
+    "max_branching": 2,
+    "branch_profile": [2, 2],
+    "recursive_mass": 2
+  },
+  "meta": {
+    "pet_format": "canonical-json"
+  }
+}
+```
+
+### Required top-level fields
+
+- `schema_version`: integer schema version for compatibility tracking
+- `n`: represented integer, with `n >= 2`
+- `pet`: canonical PET JSON representation
+- `metrics`: required structural metrics object
+
+### Optional top-level fields
+
+- `labels`: derived structural classifiers
+- `meta`: descriptive non-structural metadata
+
+### PET field
+
+`pet` stores the canonical machine-facing PET JSON representation.
+
+A PET JSON value is:
+
+- a non-empty list
+- of objects with exactly the keys `p` and `e`
+- where `p` is a prime integer
+- and `e` is either `null` (for exponent `1`) or another PET JSON value
+
+This is the only normative structural representation in JSONL scan output.
+Human-oriented renderings are out of scope for the dataset schema.
+
+### Metrics field
+
+The `metrics` object contains these required fields in schema v1:
+
+- `node_count`: total number of PET nodes
+- `leaf_count`: number of leaves (`e = null`)
+- `height`: PET height in levels
+- `max_branching`: maximum width at any local node set
+- `branch_profile`: number of nodes per depth level
+- `recursive_mass`: number of non-root nodes
+
+All metric fields above are mandatory in schema v1.
+
+### Labels field
+
+If present, `labels` contains derived structural classifiers.
+
+Schema v1 reserves the following label names:
+
+- `is_linear`
+- `is_level_uniform`
+- `is_squarefree`
+- `is_expanding`
+- `profile_shape`
+
+These fields are derived convenience values, not the source of truth for PET structure.
+
+### Meta field
+
+If present, `meta` contains descriptive metadata about record encoding.
+
+Schema v1 defines:
+
+- `pet_format`: currently `"canonical-json"`
+
+Arithmetic metadata may be added later, but it is not part of the required base schema.
+
+### Stability and future evolution
+
+Schema v1 guarantees the naming and meaning of all required fields above.
+
+Compatibility rules:
+
+- new optional fields may be added without changing `schema_version`
+- removing or renaming required fields requires a new schema version
+- changing the meaning of a required field requires a new schema version
+- downstream consumers should ignore unknown optional fields
+
+### Example JSONL line
+
+```json
+{"schema_version":1,"n":72,"pet":[{"p":2,"e":[{"p":3,"e":null}]},{"p":3,"e":[{"p":2,"e":null}]}],"metrics":{"node_count":4,"leaf_count":2,"height":2,"max_branching":2,"branch_profile":[2,2],"recursive_mass":2},"meta":{"pet_format":"canonical-json"}}
+```
+

--- a/docs/reports/metrics-2-10000.md
+++ b/docs/reports/metrics-2-10000.md
@@ -1,0 +1,96 @@
+# First reproducible PET metrics report (2..10000)
+
+## Scope
+
+This report summarizes a bounded empirical scan of PET representations for integers
+in the closed range `2..10000`.
+
+It is intended as a first reproducible report for PET metrics, with explicit inputs,
+generation path, and compact observations separated from interpretation.
+
+## Reproduction
+
+### Command
+
+    python3 -m src.pet.cli scan 2 10000 --jsonl docs/reports/data/scan-2-10000.jsonl
+
+### Output dataset
+
+- path: `docs/reports/data/scan-2-10000.jsonl`
+- record count: `9999`
+- schema: JSONL scan schema v1
+
+## Summary statistics
+
+### Height distribution
+
+| height | count |
+|---|---:|
+| 1 | 6082 |
+| 2 | 3477 |
+| 3 | 440 |
+
+### Maximum branching distribution
+
+| max_branching | count |
+|---|---:|
+| 1 | 1276 |
+| 2 | 4101 |
+| 3 | 3695 |
+| 4 | 894 |
+| 5 | 33 |
+
+### Other aggregate results
+
+| metric | value |
+|---|---:|
+| total records | 9999 |
+| records with `recursive_mass = 0` | 6082 |
+| maximum `node_count` | 7 |
+| first `n` with maximum `node_count` | 3600 |
+| maximum `height` | 3 |
+| first `n` with maximum `height` | 16 |
+| maximum `max_branching` | 5 |
+| first `n` with maximum `max_branching` | 2310 |
+
+## Concrete examples
+
+### First record reaching maximum height
+
+- `n = 16`
+- `height = 3`
+
+### First record reaching maximum branching
+
+- `n = 2310`
+- `max_branching = 5`
+
+### First record reaching maximum node count
+
+- `n = 3600`
+- `node_count = 7`
+
+## Observations
+
+1. Most PETs in `2..10000` are shallow: height `1` or `2` accounts for `9559 / 9999` records.
+
+2. Height `1` occurs exactly `6082` times, which matches the number of records with `recursive_mass = 0` in this dataset.
+
+3. The most common local branching values are `2` and `3`, while `max_branching = 5` is rare (`33` cases in `9999` records).
+
+4. The first record reaching maximum height is `16`, while the first record reaching maximum branching is `2310`, showing that depth and width peak on different inputs.
+
+5. The first record reaching the maximum observed `node_count` is `3600`, indicating that larger structural mass appears before the upper bound of the scan.
+
+## Interpretation and limits
+
+This report is descriptive only.
+
+It does not claim asymptotic laws, universality, or deep classification results.
+All observations above are bounded to the explicit range `2..10000` and depend on the current PET encoding and metric definitions.
+
+In particular:
+
+- the report is intended as a reproducible empirical baseline
+- it does not replace broader scans such as `2..10^5` or `2..10^6`
+- it does not prove that the observed distributions remain stable beyond this range

--- a/src/pet/scan.py
+++ b/src/pet/scan.py
@@ -8,9 +8,13 @@ def build_record(n: int) -> dict:
     tree = encode(n)
 
     return {
+        "schema_version": 1,
         "n": n,
         "pet": to_jsonable(tree),
         "metrics": metrics_dict(tree),
+        "meta": {
+            "pet_format": "canonical-json",
+        },
     }
 
 


### PR DESCRIPTION
## Summary
- add first bounded PET metrics report for `2..10000`
- document the exact scan command used to generate the dataset
- report compact summary statistics for height, branching, and structural mass
- separate observations from interpretation and limits

## Testing
- `python3 -m src.pet.cli scan 2 10000 --jsonl docs/reports/data/scan-2-10000.jsonl`
- verified record count is 9999
- verified emitted records follow JSONL schema v1