### PR TITLE
Consolidate PET lab workflow, docs, and report-facing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Entry point attuali:
 -   `docs/STATUS.md` — cosa è definito, provato, empirico o ancora aperto
 -   `docs/reports/canonical-workflow.md` — workflow canonico del PET lab: dataset, summary, report e classificazione
 -   `docs/reports/README.md` — indice SSOT di report, dataset e comandi di rigenerazione
+-   `docs/reports/artifact-policy.md` — policy attuale su artifact commitati, locali e rigenerabili
 -   `docs/reports/metrics-2-10000.md` — prima baseline riproducibile delle metriche
 -   `docs/reports/atlas-2-100000.md` — empirical atlas report per `2..100000`
 -   `docs/reports/atlas-2-1000000.md` — empirical atlas report per `2..1000000`

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Entry point attuali:
 -   `docs/reports/README.md` — indice SSOT di report, dataset e comandi di rigenerazione
 -   `docs/reports/artifact-policy.md` — policy attuale su artifact commitati, locali e rigenerabili
 -   `docs/reports/tooling-classification.md` — classificazione tra tooling stabile, secondario ed esplorativo
+-   `docs/reports/contributor-operator.md` — guida corta per contributor/operator del PET lab
 -   `docs/reports/metrics-2-10000.md` — prima baseline riproducibile delle metriche
 -   `docs/reports/atlas-2-100000.md` — empirical atlas report per `2..100000`
 -   `docs/reports/atlas-2-1000000.md` — empirical atlas report per `2..1000000`

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Entry point attuali:
 -   `docs/reports/canonical-workflow.md` — workflow canonico del PET lab: dataset, summary, report e classificazione
 -   `docs/reports/README.md` — indice SSOT di report, dataset e comandi di rigenerazione
 -   `docs/reports/artifact-policy.md` — policy attuale su artifact commitati, locali e rigenerabili
+-   `docs/reports/tooling-classification.md` — classificazione tra tooling stabile, secondario ed esplorativo
 -   `docs/reports/metrics-2-10000.md` — prima baseline riproducibile delle metriche
 -   `docs/reports/atlas-2-100000.md` — empirical atlas report per `2..100000`
 -   `docs/reports/atlas-2-1000000.md` — empirical atlas report per `2..1000000`

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Entry point attuali:
 -   `docs/SPEC.md` — formato, schema, metriche e contratti di comportamento
 -   `docs/STATUS.md` — cosa è definito, provato, empirico o ancora aperto
 -   `docs/reports/canonical-workflow.md` — workflow canonico del PET lab: dataset, summary, report e classificazione
+-   `docs/reports/README.md` — indice SSOT di report, dataset e comandi di rigenerazione
 -   `docs/reports/metrics-2-10000.md` — prima baseline riproducibile delle metriche
 -   `docs/reports/atlas-2-100000.md` — empirical atlas report per `2..100000`
 -   `docs/reports/atlas-2-1000000.md` — empirical atlas report per `2..1000000`

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Entry point attuali:
 
 -   `docs/SPEC.md` — formato, schema, metriche e contratti di comportamento
 -   `docs/STATUS.md` — cosa è definito, provato, empirico o ancora aperto
+-   `docs/reports/canonical-workflow.md` — workflow canonico del PET lab: dataset, summary, report e classificazione
 -   `docs/reports/metrics-2-10000.md` — prima baseline riproducibile delle metriche
 -   `docs/reports/atlas-2-100000.md` — empirical atlas report per `2..100000`
 -   `docs/reports/atlas-2-1000000.md` — empirical atlas report per `2..1000000`

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -1,0 +1,105 @@
+# PET reports and datasets index
+
+This directory is the single source of truth for PET bounded reports, their
+associated datasets, and their regeneration paths.
+
+For the canonical end-to-end lab path, see:
+- `docs/reports/canonical-workflow.md`
+
+## Directory structure
+
+- `docs/reports/` — committed bounded reports and workflow notes
+- `docs/reports/data/` — committed datasets and committed/derived summary artifacts used by bounded reports
+
+## Report index
+
+### `metrics-2-10000.md`
+
+- purpose: first reproducible bounded PET metrics baseline
+- epistemic class: descriptive report
+- bounded scope: `2..10000`
+- associated dataset: `docs/reports/data/scan-2-10000.jsonl`
+- associated summary/tooling: direct scan output
+- regeneration command:
+
+      python3 -m src.pet.cli scan 2 10000 --jsonl docs/reports/data/scan-2-10000.jsonl
+
+### `atlas-2-100000.md`
+
+- purpose: bounded empirical atlas snapshot for a medium scan range
+- epistemic class: descriptive atlas report
+- bounded scope: `2..100000`
+- associated dataset: `docs/reports/data/scan-2-100000.jsonl`
+- associated summary/tooling: `docs/reports/data/atlas-summary-2-100000.txt`, `tools/atlas_summary.py`
+- regeneration commands:
+
+      python3 -m src.pet.cli scan 2 100000 --jsonl docs/reports/data/scan-2-100000.jsonl
+      python3 tools/atlas_summary.py docs/reports/data/scan-2-100000.jsonl > docs/reports/data/atlas-summary-2-100000.txt
+
+### `atlas-2-1000000.md`
+
+- purpose: bounded empirical atlas snapshot for a larger scan range
+- epistemic class: descriptive atlas report
+- bounded scope: `2..1000000`
+- associated dataset: `docs/reports/data/scan-2-1000000.jsonl`
+- associated summary/tooling: `docs/reports/data/atlas-summary-2-1000000.txt`, `tools/atlas_summary.py`
+- regeneration commands:
+
+      python3 -m src.pet.cli scan 2 1000000 --jsonl docs/reports/data/scan-2-1000000.jsonl
+      python3 tools/atlas_summary.py docs/reports/data/scan-2-1000000.jsonl > docs/reports/data/atlas-summary-2-1000000.txt
+
+### `signatures-catalog-2-1000000.md`
+
+- purpose: first bounded catalog of PET structural signature components and minimal realizers
+- epistemic class: descriptive catalog
+- bounded scope: based on the `2..1000000` scan range
+- associated dataset: `docs/reports/data/scan-2-1000000.jsonl`
+- associated summary/tooling: atlas reports and bounded first-occurrence data from the `2..1000000` scan
+- regeneration inputs:
+  - `docs/reports/data/scan-2-1000000.jsonl`
+  - `docs/reports/atlas-2-1000000.md`
+
+### `families-benchmark-disjoint.md`
+
+- purpose: bounded comparative benchmark across disjoint classical integer families
+- epistemic class: benchmark report
+- bounded scope: fixed bounded family samples embedded in the benchmark script
+- associated dataset: none committed as a separate scan dataset
+- associated summary/tooling: `tools/cluster_families_disjoint.py`
+- regeneration command:
+
+      python3 tools/cluster_families_disjoint.py
+
+### `observation-pipeline.md`
+
+- purpose: define the vocabulary and promotion rules for PET statements
+- epistemic class: pipeline note
+- bounded scope: not a dataset report; applies to interpretation across bounded reports
+- associated dataset: none
+- associated summary/tooling: none
+
+### `canonical-workflow.md`
+
+- purpose: define the canonical PET lab path from bounded inputs to published reports
+- epistemic class: workflow note
+- bounded scope: current lab process, not a single scan range
+- associated dataset: references scan datasets and derived report artifacts
+- associated summary/tooling: `tools/atlas_summary.py`, `tools/cluster_families_disjoint.py`
+
+## Dataset and derived artifact index
+
+### Committed scan datasets
+
+- `docs/reports/data/scan-2-10000.jsonl` — source dataset for `metrics-2-10000.md`
+- `docs/reports/data/scan-2-100000.jsonl` — source dataset for `atlas-2-100000.md`
+- `docs/reports/data/scan-2-1000000.jsonl` — source dataset for `atlas-2-1000000.md` and `signatures-catalog-2-1000000.md`
+
+### Committed atlas summaries
+
+- `docs/reports/data/atlas-summary-2-100000.txt` — derived summary for `atlas-2-100000.md`
+- `docs/reports/data/atlas-summary-2-1000000.txt` — derived summary for `atlas-2-1000000.md`
+
+## Usage rule
+
+When adding a new bounded PET report, update this index so that the report
+directory remains navigable as a lab notebook rather than a loose collection of files.

--- a/docs/reports/README.md
+++ b/docs/reports/README.md
@@ -9,7 +9,7 @@ For the canonical end-to-end lab path, see:
 ## Directory structure
 
 - `docs/reports/` — committed bounded reports and workflow notes
-- `docs/reports/data/` — committed datasets and committed/derived summary artifacts used by bounded reports
+- `docs/reports/data/` — local generated datasets and local derived summary artifacts used to reproduce bounded reports under the current policy
 
 ## Report index
 
@@ -86,15 +86,15 @@ For the canonical end-to-end lab path, see:
 - associated dataset: references scan datasets and derived report artifacts
 - associated summary/tooling: `tools/atlas_summary.py`, `tools/cluster_families_disjoint.py`
 
-## Dataset and derived artifact index
+## Local dataset and derived artifact index
 
-### Committed scan datasets
+### Local generated scan datasets
 
 - `docs/reports/data/scan-2-10000.jsonl` — source dataset for `metrics-2-10000.md`
 - `docs/reports/data/scan-2-100000.jsonl` — source dataset for `atlas-2-100000.md`
 - `docs/reports/data/scan-2-1000000.jsonl` — source dataset for `atlas-2-1000000.md` and `signatures-catalog-2-1000000.md`
 
-### Committed atlas summaries
+### Local derived atlas summaries
 
 - `docs/reports/data/atlas-summary-2-100000.txt` — derived summary for `atlas-2-100000.md`
 - `docs/reports/data/atlas-summary-2-1000000.txt` — derived summary for `atlas-2-1000000.md`

--- a/docs/reports/artifact-policy.md
+++ b/docs/reports/artifact-policy.md
@@ -1,0 +1,91 @@
+# PET artifact tracking policy
+
+## Scope
+
+This document defines the current artifact policy for PET report-generation
+artifacts and local research outputs.
+
+Its purpose is to make explicit what is expected to be committed, what is
+expected to remain local, and what should not be treated as canonical repo
+state.
+
+## Artifact classes
+
+### 1. Committed source artifacts
+
+These are source-controlled files that define the PET lab workflow or publish
+stable bounded results.
+
+Examples:
+- `README.md`
+- `docs/SPEC.md`
+- `docs/STATUS.md`
+- `docs/reports/canonical-workflow.md`
+- `docs/reports/README.md`
+- bounded report documents under `docs/reports/*.md`
+
+### 2. Local generated datasets
+
+These are generated data artifacts used to reproduce or extend bounded reports,
+but they are currently treated as local working artifacts rather than committed
+repository state.
+
+Current examples:
+- `docs/reports/data/scan-2-10000.jsonl`
+- `docs/reports/data/scan-2-100000.jsonl`
+- `docs/reports/data/scan-2-1000000.jsonl`
+
+Policy:
+- generate locally when needed
+- do not assume they are present in a fresh clone
+- do not describe them as committed repo artifacts
+- use them as reproducibility inputs, but treat them as operator-side artifacts
+
+### 3. Local derived summaries
+
+These are generated from local datasets and currently remain local as well.
+
+Current examples:
+- `docs/reports/data/atlas-summary-2-100000.txt`
+- `docs/reports/data/atlas-summary-2-1000000.txt`
+
+Policy:
+- generate locally when needed
+- treat as disposable/regenerable unless future policy says otherwise
+- do not rely on them as committed repository state
+
+### 4. Exploratory local artifacts
+
+Transient charts, dumps, compressed files, binary outputs, and other one-off
+research artifacts are local unless explicitly promoted into a documented report
+workflow.
+
+Examples:
+- files under `artifacts/`
+- temporary files
+- local binary or compressed experiment outputs
+
+## Current repository rule
+
+At the current stage, `docs/reports/data/` is ignored by Git.
+
+This means:
+- report markdown files may be committed
+- datasets and summary text files under `docs/reports/data/` are local by default
+- reproducibility is command-based, not clone-completeness-based
+
+## Contributor rule
+
+When adding a new bounded report:
+- commit the report document if it is intended as part of the stable lab record
+- document the regeneration command
+- document the expected local inputs if they are not committed
+- do not silently rely on ignored local files without saying so
+
+## Future policy note
+
+This policy reflects the current repository state, not a final immutable choice.
+
+A later consolidation step may decide to version some bounded datasets or some
+derived summaries explicitly, but that must happen together with a deliberate
+`.gitignore` update and SSOT index alignment.

--- a/docs/reports/canonical-workflow.md
+++ b/docs/reports/canonical-workflow.md
@@ -96,6 +96,65 @@ Command:
 This workflow is currently script-output-backed: the report is derived from the
 benchmark script output rather than from a committed scan dataset.
 
+## Stable filenames and expected outputs
+
+### Scan step
+
+Command pattern:
+
+    python3 -m src.pet.cli scan <start> <end> --jsonl docs/reports/data/scan-<start>-<end>.jsonl
+
+Expected output:
+- committed JSONL dataset at `docs/reports/data/scan-<start>-<end>.jsonl`
+
+Stable filename pattern:
+- `scan-<start>-<end>.jsonl`
+
+### Atlas summary step
+
+Command pattern:
+
+    python3 tools/atlas_summary.py docs/reports/data/scan-<start>-<end>.jsonl > docs/reports/data/atlas-summary-<start>-<end>.txt
+
+Expected output:
+- derived summary text at `docs/reports/data/atlas-summary-<start>-<end>.txt`
+
+Stable filename pattern:
+- `atlas-summary-<start>-<end>.txt`
+
+### Atlas report step
+
+Expected output:
+- committed report at `docs/reports/atlas-<start>-<end>.md`
+
+Stable filename pattern:
+- `atlas-<start>-<end>.md`
+
+### Metrics baseline step
+
+Current canonical example:
+- dataset: `docs/reports/data/scan-2-10000.jsonl`
+- report: `docs/reports/metrics-2-10000.md`
+
+Expected output:
+- committed bounded metrics report
+
+Current stable filename:
+- `metrics-2-10000.md`
+
+### Family benchmark step
+
+Command pattern:
+
+    python3 tools/cluster_families_disjoint.py
+
+Expected output:
+- stdout from the benchmark script, to be used when preparing
+  `docs/reports/families-benchmark-disjoint.md`
+
+Current stable report filename:
+- `families-benchmark-disjoint.md`
+
 ### 5. Classify statements before promoting them
 
 Interpretation must follow `docs/reports/observation-pipeline.md`.

--- a/docs/reports/canonical-workflow.md
+++ b/docs/reports/canonical-workflow.md
@@ -1,0 +1,109 @@
+# PET canonical workflow
+
+## Scope
+
+This document defines the current canonical workflow for PET as a bounded,
+reproducible structural laboratory for integers.
+
+It does not define PET semantics, proof status, or future theory.
+Those belong respectively to `docs/SPEC.md`, `docs/STATUS.md`, and research notes.
+
+## Purpose
+
+The canonical workflow exists to ensure that PET results are produced,
+summarized, and interpreted through a stable, explicit pipeline rather than
+through scattered ad-hoc exploration.
+
+## Canonical pipeline
+
+### 1. Produce a bounded scan dataset
+
+Primary artifact:
+- `docs/reports/data/scan-<start>-<end>.jsonl`
+
+Command pattern:
+
+    python3 -m src.pet.cli scan <start> <end> --jsonl docs/reports/data/scan-<start>-<end>.jsonl
+
+This dataset is the base empirical artifact for downstream reporting.
+
+### 2. Produce an atlas-style summary from the scan dataset
+
+Primary helper:
+- `tools/atlas_summary.py`
+
+Derived artifact:
+- `docs/reports/data/atlas-summary-<start>-<end>.txt`
+
+Command pattern:
+
+    python3 tools/atlas_summary.py docs/reports/data/scan-<start>-<end>.jsonl > docs/reports/data/atlas-summary-<start>-<end>.txt
+
+This step converts the raw bounded scan into a compact structural summary.
+
+### 3. Publish a bounded report tied to explicit inputs
+
+Primary artifacts:
+- `docs/reports/atlas-<start>-<end>.md`
+- other bounded report documents under `docs/reports/`
+
+A report is canonical only if it states:
+- its bounded range
+- the input dataset it depends on
+- the command path used to reproduce it
+- whether it is descriptive, comparative, or classificatory
+
+### 4. Derive higher-level bounded artifacts from explicit datasets
+
+Current bounded artifact families include:
+- atlas reports
+- signature catalogs
+- family benchmarks
+- metrics baselines
+
+These artifacts must stay tied to explicit bounded inputs and must not be
+presented as general theory by default.
+
+### 5. Classify statements before promoting them
+
+Interpretation must follow `docs/reports/observation-pipeline.md`.
+
+In practice:
+- raw bounded facts belong in reports
+- repeated bounded regularities may be called bounded empirical patterns
+- beyond-range claims must be marked as conjectures
+- proved or definitional statements belong to established status
+
+## Current canonical artifacts
+
+Stable entry points currently recognized by the repository:
+
+- `docs/SPEC.md`
+- `docs/STATUS.md`
+- `docs/reports/metrics-2-10000.md`
+- `docs/reports/atlas-2-100000.md`
+- `docs/reports/atlas-2-1000000.md`
+- `docs/reports/signatures-catalog-2-1000000.md`
+- `docs/reports/families-benchmark-disjoint.md`
+- `docs/reports/observation-pipeline.md`
+
+## Current stable vs non-canonical boundary
+
+Canonical workflow does **not** mean every script in `tools/` is stable.
+
+At the current stage, the canonical lab path is centered on:
+- bounded scan generation
+- atlas-style summarization
+- bounded report publication
+- explicit statement classification
+
+Exploratory scripts may still be useful, but they are not automatically part of
+the canonical workflow unless a report or stable document explicitly relies on them.
+
+## Usage rule
+
+When adding a new PET report, prefer extending the existing bounded pipeline
+instead of inventing a parallel undocumented flow.
+
+If a result cannot be reproduced from explicit bounded inputs with a clear command
+path, it should not be treated as a canonical PET lab artifact.

--- a/docs/reports/canonical-workflow.md
+++ b/docs/reports/canonical-workflow.md
@@ -64,6 +64,38 @@ Current bounded artifact families include:
 These artifacts must stay tied to explicit bounded inputs and must not be
 presented as general theory by default.
 
+### 4a. Metrics baseline workflow
+
+Canonical path:
+- generate a bounded scan dataset
+- publish a descriptive metrics report tied to that dataset
+
+Current example:
+- dataset: `docs/reports/data/scan-2-10000.jsonl`
+- report: `docs/reports/metrics-2-10000.md`
+
+Command:
+
+    python3 -m src.pet.cli scan 2 10000 --jsonl docs/reports/data/scan-2-10000.jsonl
+
+The metrics baseline is currently scan-backed rather than driven by a separate
+stable summary script.
+
+### 4b. Family benchmark workflow
+
+Primary helper:
+- `tools/cluster_families_disjoint.py`
+
+Current example:
+- report: `docs/reports/families-benchmark-disjoint.md`
+
+Command:
+
+    python3 tools/cluster_families_disjoint.py
+
+This workflow is currently script-output-backed: the report is derived from the
+benchmark script output rather than from a committed scan dataset.
+
 ### 5. Classify statements before promoting them
 
 Interpretation must follow `docs/reports/observation-pipeline.md`.

--- a/docs/reports/contributor-operator.md
+++ b/docs/reports/contributor-operator.md
@@ -1,0 +1,92 @@
+# PET contributor and operator guide
+
+## Who this is for
+
+This guide is for contributors or operators who want to reproduce bounded PET
+reports or add a new one without reverse-engineering repo habits.
+
+## Start here
+
+Read these documents in this order:
+
+1. `README.md`
+2. `docs/reports/canonical-workflow.md`
+3. `docs/reports/README.md`
+4. `docs/reports/artifact-policy.md`
+5. `docs/reports/tooling-classification.md`
+6. `docs/reports/observation-pipeline.md`
+
+## Current canonical lab path
+
+The current canonical PET lab path is:
+
+1. generate a bounded scan dataset
+2. generate an atlas-style summary if the report needs it
+3. publish a bounded report tied to explicit inputs
+4. classify statements correctly before promoting them
+
+Canonical examples already in use:
+- metrics baseline: `docs/reports/metrics-2-10000.md`
+- atlas reports: `docs/reports/atlas-2-100000.md`, `docs/reports/atlas-2-1000000.md`
+- family benchmark: `docs/reports/families-benchmark-disjoint.md`
+
+## Core commands
+
+Generate a bounded scan dataset:
+
+    python3 -m src.pet.cli scan <start> <end> --jsonl docs/reports/data/scan-<start>-<end>.jsonl
+
+Generate an atlas-style summary from a scan dataset:
+
+    python3 tools/atlas_summary.py docs/reports/data/scan-<start>-<end>.jsonl > docs/reports/data/atlas-summary-<start>-<end>.txt
+
+Run the current canonical family benchmark:
+
+    python3 tools/cluster_families_disjoint.py
+
+## Tooling boundary
+
+Treat these as stable research tooling:
+- `tools/atlas_summary.py`
+- `tools/cluster_families_disjoint.py`
+
+Treat `tools/cluster_families.py` as secondary/non-canonical.
+
+Do not assume the rest of `tools/` is part of the canonical lab workflow.
+
+## Artifact rule
+
+Under the current repository policy:
+- report markdown files under `docs/reports/` may be committed
+- `docs/reports/data/` is local and Git-ignored
+- local datasets and atlas summaries are reproducibility inputs, not committed repo state
+
+Do not write docs that pretend ignored local data files are present in a fresh clone.
+
+## Claim classification rule
+
+Use `docs/reports/observation-pipeline.md`.
+
+In practice:
+- bounded facts stay bounded
+- repeated bounded regularities are still not proofs
+- beyond-range claims must be marked as conjectures
+- definitional or proved facts belong to established status
+
+## How to add a new bounded report
+
+1. decide the bounded scope explicitly
+2. generate the required local dataset or benchmark output
+3. write the report as descriptive, comparative, benchmark, catalog, or workflow note
+4. state the exact regeneration command(s)
+5. state the local inputs the report depends on
+6. classify statements conservatively
+7. update `docs/reports/README.md` if the report becomes part of the stable lab record
+
+## What not to do
+
+- do not promote bounded findings into general theory silently
+- do not treat exploratory scripts as stable lab interfaces by default
+- do not assume local ignored data artifacts are committed
+- do not add a new parallel workflow without documenting it
+

--- a/docs/reports/tooling-classification.md
+++ b/docs/reports/tooling-classification.md
@@ -1,0 +1,93 @@
+# PET tooling classification
+
+## Scope
+
+This document classifies the current `tools/` scripts into stable research
+tooling, secondary/non-canonical tooling, and exploratory scripts.
+
+Its goal is to make the PET lab boundary explicit so that workflow documents do
+not accidentally treat one-off scripts as stable interfaces.
+
+## Stable research tooling
+
+These scripts are part of the current bounded PET lab workflow and are already
+referenced by stable documentation or committed reports.
+
+### `tools/atlas_summary.py`
+
+Status:
+- stable research tooling
+
+Reason:
+- explicitly used by atlas reports
+- explicitly referenced by `README.md`
+- explicitly referenced by `docs/reports/canonical-workflow.md`
+- consumes bounded scan JSONL input and produces atlas-style summary output
+
+### `tools/cluster_families_disjoint.py`
+
+Status:
+- stable research tooling
+
+Reason:
+- explicitly used by `docs/reports/families-benchmark-disjoint.md`
+- explicitly referenced by `README.md`
+- explicitly referenced by `docs/reports/canonical-workflow.md`
+- currently defines the canonical family benchmark path
+
+## Secondary / non-canonical research tooling
+
+These scripts are related to documented PET analysis, but are not currently part
+of the canonical bounded lab workflow.
+
+### `tools/cluster_families.py`
+
+Status:
+- secondary research tooling
+- not part of the current canonical workflow
+
+Reason:
+- cited in `docs/SPEC.md`
+- superseded in the current report workflow by `tools/cluster_families_disjoint.py`
+- still meaningful, but not the benchmark path currently promoted by stable lab docs
+
+## Exploratory / one-off tooling
+
+The following scripts are currently exploratory, local, prototype, plotting, or
+one-off analysis tools rather than stable workflow interfaces:
+
+- `tools/analyze_generators.py`
+- `tools/distinct_shapes.py`
+- `tools/distinct_shapes_streamed.py`
+- `tools/entropy_growth.py`
+- `tools/explore.py`
+- `tools/exp_vectors.py`
+- `tools/height_distribution.py`
+- `tools/omega_distribution.py`
+- `tools/pet_compressor_prototipo.py`
+- `tools/plot_diagonal_law.py`
+- `tools/plot_shape_birth.py`
+- `tools/plot_shape_growth_law.py`
+- `tools/shape_count_fast.py`
+- `tools/shape_entropy.py`
+- `tools/shape_evolution_graph.py`
+- `tools/shape_first_occurrence.py`
+- `tools/shape_graph.py`
+- `tools/shapes_growth.py`
+- `tools/test_diagonal_ratio.py`
+
+Common reasons:
+- not referenced by the current canonical workflow
+- not used directly by committed bounded reports
+- rely on hardcoded local paths or local `artifacts/`
+- look like prototypes, exploratory utilities, or plotting helpers
+- no current stability promise should be inferred from their presence in `tools/`
+
+## Usage rule
+
+Workflow docs, contributor docs, and report regeneration notes should treat only
+the current stable research tooling as interface-stable unless this document is
+updated.
+
+Exploratory scripts may still be useful for investigation, but they should not
+be presented as canonical PET lab commands by default.

--- a/tests/test_atlas_summary.py
+++ b/tests/test_atlas_summary.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_atlas_summary_small_scan(tmp_path):
+    jsonl_path = tmp_path / "scan.jsonl"
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pet.cli",
+            "scan",
+            "2",
+            "12",
+            "--jsonl",
+            str(jsonl_path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    result = subprocess.run(
+        [sys.executable, "tools/atlas_summary.py", str(jsonl_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    expected = """total_records: 11
+distinct_shapes: 4
+shape_entropy: 1.240684291953
+max_entropy: 1.386294361120
+max_node_count: 3
+first_n_with_max_node_count: 12
+max_height: 2
+first_n_with_max_height: 4
+max_branching: 2
+first_n_with_max_branching: 6
+
+[height_distribution]
+1 7
+2 4
+
+[max_branching_distribution]
+1 8
+2 3
+"""
+    assert result.stdout == expected

--- a/tests/test_atlas_summary_empty.py
+++ b/tests/test_atlas_summary_empty.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+
+
+def test_atlas_summary_empty_input(tmp_path):
+    jsonl_path = tmp_path / "empty.jsonl"
+    jsonl_path.write_text("", encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, "tools/atlas_summary.py", str(jsonl_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    expected = """total_records: 0
+distinct_shapes: 0
+shape_entropy: 0.000000000000
+max_entropy: 0.000000000000
+max_node_count: -1
+first_n_with_max_node_count: None
+max_height: -1
+first_n_with_max_height: None
+max_branching: -1
+first_n_with_max_branching: None
+
+[height_distribution]
+
+[max_branching_distribution]
+"""
+    assert result.stdout == expected

--- a/tests/test_cluster_families_disjoint.py
+++ b/tests/test_cluster_families_disjoint.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+
+
+def test_cluster_families_disjoint_runs_and_prints_key_sections():
+    result = subprocess.run(
+        [sys.executable, "tools/cluster_families_disjoint.py"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    out = result.stdout
+
+    assert "PET — Clustering famiglie aritmetiche (DISGIUNTE)" in out
+    assert "Priorità: Perfect > Primorials > Hamming > HighlyComposite" in out
+    assert "SOVRAPPOSIZIONI — elementi rimossi per disgiunzione" in out
+    assert "Perfect" in out
+    assert "Primorials" in out
+    assert "Hamming" in out
+    assert "HighlyComposite" in out
+    assert "Distanze INTER-famiglia — distance" in out
+    assert "Distanze INTER-famiglia — structural_distance" in out
+    assert "Separabilità (distance):" in out
+    assert "Separabilità (structural_distance):" in out
+    assert "Fine analisi." in out

--- a/tests/test_scan_jsonl_schema.py
+++ b/tests/test_scan_jsonl_schema.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+import sys
+
+
+def test_scan_jsonl_schema(tmp_path):
+    jsonl_path = tmp_path / "scan.jsonl"
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pet.cli",
+            "scan",
+            "2",
+            "4",
+            "--jsonl",
+            str(jsonl_path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    rows = [json.loads(line) for line in jsonl_path.read_text(encoding="utf-8").splitlines()]
+
+    assert [row["n"] for row in rows] == [2, 3, 4]
+
+    for row in rows:
+        assert set(row.keys()) == {"schema_version", "n", "pet", "metrics", "meta"}
+        assert row["schema_version"] == 1
+        assert row["meta"] == {"pet_format": "canonical-json"}
+
+        assert set(row["metrics"].keys()) == {
+            "node_count",
+            "leaf_count",
+            "height",
+            "max_branching",
+            "branch_profile",
+            "recursive_mass",
+        }
+
+    assert rows[0]["pet"] == [{"p": 2, "e": None}]
+    assert rows[1]["pet"] == [{"p": 3, "e": None}]
+    assert rows[2]["pet"] == [{"p": 2, "e": [{"p": 2, "e": None}]}]


### PR DESCRIPTION
## Summary
- define and refine the canonical PET lab workflow
- add a reports/datasets SSOT index and align it with the current artifact policy
- document artifact tracking, tooling classification, and contributor/operator guidance
- add report-facing regression coverage for scan JSONL, atlas summary, empty atlas summary input, and the disjoint family benchmark script

## Testing
- pytest -q tests/test_atlas_summary.py tests/test_atlas_summary_empty.py tests/test_scan_jsonl_schema.py tests/test_cluster_families_disjoint.py

Closes #25