### PR TITLE
tests: extend report contract checks to the signatures catalog report

### DIFF
--- a/tests/test_report_contracts.py
+++ b/tests/test_report_contracts.py
@@ -14,6 +14,9 @@ REPORT_CONTRACTS = {
     "docs/reports/families-benchmark-disjoint.md": {
         "kind": "script-backed-benchmark",
     },
+    "docs/reports/signatures-catalog-2-1000000.md": {
+        "kind": "scan-backed",
+    },
 }
 
 


### PR DESCRIPTION
## Summary

Extend `tests/test_report_contracts.py` to cover `docs/reports/signatures-catalog-2-1000000.md` after its recent report-facing alignment.

## Changes

- add `docs/reports/signatures-catalog-2-1000000.md` to `REPORT_CONTRACTS`
- classify it as `scan-backed`
- broaden report contract coverage without introducing a new contract kind

## Notes

The updated signatures catalog now satisfies the existing minimum structural contract expected for scan-backed reports.

This change keeps the current contract model intact and avoids fragile wording-based exceptions.