### PR TITLE
tests: cover atlas-2-1000000 in report contracts

### DIFF
--- a/tests/test_report_contracts.py
+++ b/tests/test_report_contracts.py
@@ -11,6 +11,9 @@ REPORT_CONTRACTS = {
     "docs/reports/atlas-2-100000.md": {
         "kind": "scan+summary-backed",
     },
+    "docs/reports/atlas-2-1000000.md": {
+        "kind": "scan+summary-backed",
+    },
     "docs/reports/families-benchmark-disjoint.md": {
         "kind": "script-backed-benchmark",
     },


### PR DESCRIPTION
## Summary

Extend `tests/test_report_contracts.py` to cover
`docs/reports/atlas-2-1000000.md`.

Closes #38.

## What changed

- add `docs/reports/atlas-2-1000000.md` to `REPORT_CONTRACTS`
- classify it as `scan+summary-backed`
- keep the existing report contract model unchanged

## Validation

- ran `pytest -q tests/test_report_contracts.py`
- result: `5 passed`

## Scope notes

This is a small consistency extension:
- no new contract kind
- no broader refactor of the test
- no workflow expansion