### PR TITLE
docs: add minimal smoke run to operator guide

### DIFF
--- a/docs/reports/contributor-operator.md
+++ b/docs/reports/contributor-operator.md
@@ -44,6 +44,27 @@ Run the current canonical family benchmark:
 
     python3 tools/cluster_families_disjoint.py
 
+## Minimal smoke run
+
+A small bounded run can be used as a quick operator-side smoke check for the
+current scan + summary path.
+
+Example:
+
+    python3 -m src.pet.cli scan 2 5000 --jsonl docs/reports/data/scan-2-5000.jsonl
+    python3 tools/atlas_summary.py docs/reports/data/scan-2-5000.jsonl > docs/reports/data/atlas-summary-2-5000.txt
+
+Quick checks:
+
+    ls -lh docs/reports/data/scan-2-5000.jsonl
+    tail -n 3 docs/reports/data/scan-2-5000.jsonl
+    ls -lh docs/reports/data/atlas-summary-2-5000.txt
+    sed -n '1,120p' docs/reports/data/atlas-summary-2-5000.txt
+
+Notes:
+- these files are local operator-side artifacts under the current artifact policy
+- this is a smoke run for the bounded scan + summary workflow, not a committed report artifact by itself
+
 ## Tooling boundary
 
 Treat these as stable research tooling:


### PR DESCRIPTION
## Summary

Add a short `Minimal smoke run` section to
`docs/reports/contributor-operator.md`.

Closes #40.

## What changed

- document a small bounded scan + summary example using `2..5000`
- include quick inspection commands for the generated local artifacts
- clarify that the generated files are local operator-side artifacts
- keep the example framed as a smoke run, not as a new canonical report artifact

## Why this helps

This makes the contributor/operator guide more practical for first-pass repo use
by documenting a small hands-on run grounded in the current canonical workflow
and artifact policy.

## Scope notes

This is intentionally small and docs-only:
- no workflow expansion
- no new artifact policy
- no new stability promise
- no committed dataset addition