### PR TITLE
tools: add scan JSONL query helper

### DIFF
--- a/tests/test_scan_query.py
+++ b/tests/test_scan_query.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+
+
+def test_scan_query_filter_height_and_branching(tmp_path):
+    jsonl_path = tmp_path / "scan.jsonl"
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pet.cli",
+            "scan",
+            "2",
+            "30",
+            "--jsonl",
+            str(jsonl_path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "tools/scan_query.py",
+            "filter",
+            str(jsonl_path),
+            "--where",
+            "height=2",
+            "--where",
+            "max_branching>=2",
+            "--limit",
+            "5",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    expected = """{"schema_version": 1, "n": 12, "pet": [{"p": 2, "e": [{"p": 2, "e": null}]}, {"p": 3, "e": null}], "metrics": {"node_count": 3, "leaf_count": 2, "height": 2, "max_branching": 2, "branch_profile": [2, 1], "recursive_mass": 1}, "meta": {"pet_format": "canonical-json"}}
+{"schema_version": 1, "n": 18, "pet": [{"p": 2, "e": null}, {"p": 3, "e": [{"p": 2, "e": null}]}], "metrics": {"node_count": 3, "leaf_count": 2, "height": 2, "max_branching": 2, "branch_profile": [2, 1], "recursive_mass": 1}, "meta": {"pet_format": "canonical-json"}}
+{"schema_version": 1, "n": 20, "pet": [{"p": 2, "e": [{"p": 2, "e": null}]}, {"p": 5, "e": null}], "metrics": {"node_count": 3, "leaf_count": 2, "height": 2, "max_branching": 2, "branch_profile": [2, 1], "recursive_mass": 1}, "meta": {"pet_format": "canonical-json"}}
+{"schema_version": 1, "n": 24, "pet": [{"p": 2, "e": [{"p": 3, "e": null}]}, {"p": 3, "e": null}], "metrics": {"node_count": 3, "leaf_count": 2, "height": 2, "max_branching": 2, "branch_profile": [2, 1], "recursive_mass": 1}, "meta": {"pet_format": "canonical-json"}}
+{"schema_version": 1, "n": 28, "pet": [{"p": 2, "e": [{"p": 2, "e": null}]}, {"p": 7, "e": null}], "metrics": {"node_count": 3, "leaf_count": 2, "height": 2, "max_branching": 2, "branch_profile": [2, 1], "recursive_mass": 1}, "meta": {"pet_format": "canonical-json"}}
+"""
+    assert result.stdout == expected
+
+
+def test_scan_query_group_count_branch_profile(tmp_path):
+    jsonl_path = tmp_path / "scan.jsonl"
+
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pet.cli",
+            "scan",
+            "2",
+            "12",
+            "--jsonl",
+            str(jsonl_path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "tools/scan_query.py",
+            "group-count",
+            str(jsonl_path),
+            "--field",
+            "branch_profile",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    expected = """[1]\t5
+[1, 1]\t3
+[2]\t2
+[2, 1]\t1
+"""
+    normalized = "\n".join(line.split() for line in [])
+    assert "\n".join(" ".join(line.split()) for line in result.stdout.strip().splitlines()) == \
+        "\n".join(" ".join(line.split()) for line in expected.strip().splitlines())

--- a/tools/scan_query.py
+++ b/tools/scan_query.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Small operator-side query helper for PET scan JSONL artifacts."""
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+ALLOWED_FIELDS = {
+    "height",
+    "max_branching",
+    "node_count",
+    "recursive_mass",
+    "branch_profile",
+}
+
+WHERE_RE = re.compile(r"^(?P<field>[a-z_]+)(?P<op>>=|<=|=)(?P<value>.+)$")
+
+
+def load_rows(path: str):
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            yield json.loads(line)
+
+
+def parse_value(field: str, raw: str) -> Any:
+    raw = raw.strip()
+    if field == "branch_profile":
+        try:
+            value = ast.literal_eval(raw)
+        except (SyntaxError, ValueError) as exc:
+            raise SystemExit(f"Invalid branch_profile value: {raw}") from exc
+        if not isinstance(value, list) or not all(isinstance(x, int) for x in value):
+            raise SystemExit(f"branch_profile must be a list of ints: {raw}")
+        return value
+
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise SystemExit(f"Expected integer value for {field}: {raw}") from exc
+
+
+def parse_where(expr: str):
+    match = WHERE_RE.match(expr.strip())
+    if not match:
+        raise SystemExit(f"Invalid --where expression: {expr}")
+
+    field = match.group("field")
+    op = match.group("op")
+    raw_value = match.group("value")
+
+    if field not in ALLOWED_FIELDS:
+        raise SystemExit(f"Unsupported field in --where: {field}")
+
+    value = parse_value(field, raw_value)
+
+    if field == "branch_profile" and op != "=":
+        raise SystemExit("branch_profile only supports '='")
+
+    return field, op, value
+
+
+def row_value(row: dict, field: str):
+    return row["metrics"][field]
+
+
+def matches_all(row: dict, conditions: list[tuple[str, str, Any]]) -> bool:
+    for field, op, expected in conditions:
+        actual = row_value(row, field)
+
+        if op == "=":
+            if actual != expected:
+                return False
+        elif op == ">=":
+            if actual < expected:
+                return False
+        elif op == "<=":
+            if actual > expected:
+                return False
+        else:
+            raise SystemExit(f"Unsupported operator: {op}")
+
+    return True
+
+
+def cmd_filter(args: argparse.Namespace) -> int:
+    conditions = [parse_where(expr) for expr in args.where]
+    shown = 0
+
+    for row in load_rows(args.jsonl_path):
+        if matches_all(row, conditions):
+            print(json.dumps(row, ensure_ascii=False))
+            shown += 1
+            if args.limit is not None and shown >= args.limit:
+                break
+
+    return 0
+
+
+def cmd_group_count(args: argparse.Namespace) -> int:
+    field = args.field
+    if field not in ALLOWED_FIELDS:
+        raise SystemExit(f"Unsupported field for --field: {field}")
+
+    counter = Counter()
+
+    for row in load_rows(args.jsonl_path):
+        value = row_value(row, field)
+        key = tuple(value) if isinstance(value, list) else value
+        counter[key] += 1
+
+    for key, count in sorted(counter.items(), key=lambda item: (-item[1], item[0])):
+        printable = list(key) if isinstance(key, tuple) else key
+        print(f"{printable}\t{count}")
+
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Small operator-side query helper for PET scan JSONL artifacts."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    p_filter = subparsers.add_parser("filter", help="Filter scan rows by simple metric predicates")
+    p_filter.add_argument("jsonl_path", help="Path to scan JSONL file")
+    p_filter.add_argument(
+        "--where",
+        action="append",
+        default=[],
+        help="Predicate like height=3, max_branching>=3, branch_profile=[3,1,1]",
+    )
+    p_filter.add_argument("--limit", type=int, default=None, help="Maximum number of matching rows to print")
+    p_filter.set_defaults(func=cmd_filter)
+
+    p_group = subparsers.add_parser("group-count", help="Count rows grouped by one metric field")
+    p_group.add_argument("jsonl_path", help="Path to scan JSONL file")
+    p_group.add_argument("--field", required=True, help="Metric field to group by")
+    p_group.set_defaults(func=cmd_group_count)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    path = Path(args.jsonl_path)
+    if not path.exists():
+        raise SystemExit(f"File not found: {args.jsonl_path}")
+
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Add a small operator-side query helper for PET scan JSONL artifacts.

Closes #42.

## What changed

- add `tools/scan_query.py`
- support simple `filter` queries on existing scan metrics
- support `group-count` queries on one metric field
- add `tests/test_scan_query.py`

## Supported scope

The helper is intentionally small and operator-oriented.

Current capabilities:
- `filter` with simple predicates on:
  - `height`
  - `max_branching`
  - `node_count`
  - `recursive_mass`
  - `branch_profile` (equality only)
- `group-count` by one field at a time

## Validation

Ran:

- `pytest -q tests/test_scan_query.py`

Result:

- `2 passed`

## Scope notes

This does not change:
- scan schema
- canonical workflow
- report pipeline
- artifact policy

It is a small exploratory/operator-side helper for bounded scan inspection.